### PR TITLE
Fix stats page: visible tag pills + non-wrapping filter buttons

### DIFF
--- a/frontend/src/app/tasks/task-stats/task-stats.component.css
+++ b/frontend/src/app/tasks/task-stats/task-stats.component.css
@@ -7,6 +7,12 @@
   height: 360px;
 }
 
+/* Keep segmented-control labels (e.g. "Per day") on a single line so a squeezed
+   button group shrinks horizontally instead of wrapping and growing taller. */
+.btn-group .btn {
+  white-space: nowrap;
+}
+
 .tag-pill {
   cursor: pointer;
   font-size: 0.8rem;

--- a/frontend/src/app/tasks/task-stats/task-stats.component.html
+++ b/frontend/src/app/tasks/task-stats/task-stats.component.html
@@ -5,13 +5,13 @@
 
 <!-- Filter bar (writes to the URL; shareable/bookmarkable) -->
 <div class="d-flex flex-column flex-lg-row gap-2 mb-3">
-  <div class="btn-group btn-group-sm" role="group" aria-label="completion filter">
+  <div class="btn-group btn-group-sm flex-shrink-0" role="group" aria-label="completion filter">
     <button type="button" class="btn" [class]="completedState() === 'all' ? 'btn-primary' : 'btn-outline-primary'" (click)="setCompleted('all')">All</button>
     <button type="button" class="btn" [class]="completedState() === 'todo' ? 'btn-primary' : 'btn-outline-primary'" (click)="setCompleted('todo')">Todo</button>
     <button type="button" class="btn" [class]="completedState() === 'done' ? 'btn-primary' : 'btn-outline-primary'" (click)="setCompleted('done')">Completed</button>
   </div>
 
-  <div class="btn-group btn-group-sm" role="group" aria-label="time bucket">
+  <div class="btn-group btn-group-sm flex-shrink-0" role="group" aria-label="time bucket">
     <button type="button" class="btn" [class]="bucket() === 'day' ? 'btn-primary' : 'btn-outline-primary'" (click)="setBucket('day')">Per day</button>
     <button type="button" class="btn" [class]="bucket() === 'week' ? 'btn-primary' : 'btn-outline-primary'" (click)="setBucket('week')">Per week</button>
   </div>
@@ -26,7 +26,7 @@
 
 <!-- Period: scopes the dashboard by completion date -->
 <div class="d-flex flex-column flex-lg-row gap-2 mb-3 align-items-lg-center">
-  <div class="btn-group btn-group-sm" role="group" aria-label="period">
+  <div class="btn-group btn-group-sm flex-shrink-0" role="group" aria-label="period">
     <button type="button" class="btn" [class]="activePeriod() === 'today' ? 'btn-primary' : 'btn-outline-primary'" (click)="setPeriod('today')">Today</button>
     <button type="button" class="btn" [class]="activePeriod() === 'week' ? 'btn-primary' : 'btn-outline-primary'" (click)="setPeriod('week')">Last week</button>
     <button type="button" class="btn" [class]="activePeriod() === 'month' ? 'btn-primary' : 'btn-outline-primary'" (click)="setPeriod('month')">Last month</button>
@@ -49,7 +49,7 @@
     @for (tag of allTags(); track tag.id) {
       <button type="button" class="badge rounded-pill tag-pill border-0"
               [style.background-color]="isTagActive(tag) ? tag.color : 'transparent'"
-              [style.color]="isTagActive(tag) ? (tag | tagColor) : null"
+              [style.color]="isTagActive(tag) ? (tag | tagColor) : tag.color"
               [style.box-shadow]="'inset 0 0 0 1px ' + tag.color"
               (click)="toggleTag(tag)" [attr.aria-pressed]="isTagActive(tag)"
               title="Toggle #{{ tag.name }} filter">#{{ tag.name }}</button>


### PR DESCRIPTION
## Summary
Two UI fixes on the Task Stats page.

**1. Empty-looking tag filter pills.** Inactive pills set `[style.color]="… : null"`, so labels fell back to Bootstrap's default `.badge` color (white) — invisible on the transparent pill over a white page, leaving only the colored outline. Inactive labels now use the tag's own color to match their border (a proper outline pill); active pills unchanged.

**2. "Per day / Per week" buttons expanding vertically.** Bootstrap 5's `.btn` no longer forces `white-space: nowrap`, so the segmented control's label wrapped ("Per day" → "Per" / "day") and grew taller when the flex row got tight. Button groups now keep their natural width (`flex-shrink-0`) and labels never wrap. Applied to all three segmented controls (completion / bucket / period) for consistency.

## Testing
- `ng build` (development) — compiles and type-checks cleanly, including the `task-stats-component` chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)