### PR TITLE
Fix OAuth issuer mismatch breaking Claude MCP connector discovery

### DIFF
--- a/mcp_server/oauth_views.py
+++ b/mcp_server/oauth_views.py
@@ -17,6 +17,7 @@ from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from oauth2_provider.generators import generate_client_id, generate_client_secret
 from oauth2_provider.models import get_application_model
+from pydantic import AnyHttpUrl
 
 Application = get_application_model()
 
@@ -25,11 +26,19 @@ def _abs(viewname: str) -> str:
     return settings.MCP_BASE_URL + reverse(viewname)
 
 
+def _issuer() -> str:
+    # Must byte-for-byte match the MCP protected-resource metadata's `authorization_servers`
+    # entry, which the SDK derives from `AnyHttpUrl(MCP_BASE_URL)` (which appends a trailing
+    # slash for a host-only URL). RFC 8414 requires the issuer to match the identifier the
+    # client discovered, and strict clients (Claude) reject the flow otherwise.
+    return str(AnyHttpUrl(settings.MCP_BASE_URL))
+
+
 def authorization_server_metadata(request):
     """RFC 8414 metadata served at /.well-known/oauth-authorization-server."""
     return JsonResponse(
         {
-            "issuer": settings.MCP_BASE_URL,
+            "issuer": _issuer(),
             "authorization_endpoint": _abs("oauth2_provider:authorize"),
             "token_endpoint": _abs("oauth2_provider:token"),
             "introspection_endpoint": _abs("oauth2_provider:introspect"),

--- a/mcp_server/tests/test_asgi.py
+++ b/mcp_server/tests/test_asgi.py
@@ -43,4 +43,11 @@ class ASGIDiscoveryTests(SimpleTestCase):
     def test_non_mcp_path_is_routed_to_django(self):
         response = self.asgi.get("/.well-known/oauth-authorization-server")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["issuer"], settings.MCP_BASE_URL)
+        self.assertEqual(response.json()["issuer"].rstrip("/"), settings.MCP_BASE_URL.rstrip("/"))
+
+    def test_as_issuer_matches_protected_resource_authorization_server(self):
+        # Regression: strict OAuth clients (Claude) reject discovery unless the AS metadata
+        # `issuer` byte-for-byte equals the protected-resource metadata's authorization server.
+        prm = self.asgi.get("/.well-known/oauth-protected-resource/mcp").json()
+        asm = self.asgi.get("/.well-known/oauth-authorization-server").json()
+        self.assertEqual(asm["issuer"], prm["authorization_servers"][0])

--- a/mcp_server/tests/test_oauth_views.py
+++ b/mcp_server/tests/test_oauth_views.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 from oauth2_provider.models import get_application_model
+from pydantic import AnyHttpUrl
 
 Application = get_application_model()
 
@@ -15,7 +16,8 @@ class AuthorizationServerMetadataTests(TestCase):
         response = self.client.get(reverse("oauth_as_metadata"))
         self.assertEqual(response.status_code, 200)
         body = response.json()
-        self.assertEqual(body["issuer"], settings.MCP_BASE_URL)
+        # Issuer must match the normalized form the MCP protected-resource metadata advertises.
+        self.assertEqual(body["issuer"], str(AnyHttpUrl(settings.MCP_BASE_URL)))
         self.assertTrue(body["authorization_endpoint"].endswith("/o/authorize/"))
         self.assertTrue(body["token_endpoint"].endswith("/o/token/"))
         self.assertTrue(body["registration_endpoint"].endswith("/o/register/"))


### PR DESCRIPTION
The MCP protected-resource metadata advertises `authorization_servers: ["https://organizer.yetilabs.ro/"]` (SDK normalizes via pydantic `AnyHttpUrl`, trailing slash), but the RFC 8414 AS metadata returned `issuer: "https://organizer.yetilabs.ro"` (no slash). RFC 8414 requires an exact issuer match, so Claude rejected discovery and opened the site root (empty screen, no auth prompt).

Fix: derive the issuer with `AnyHttpUrl(MCP_BASE_URL)` so it matches byte-for-byte. Adds a regression test asserting AS `issuer` == PRM `authorization_servers[0]`. Targeted tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)