### PR TITLE
Fix celery crash when RECURRING_TASKS_HOUR has an inline comment

### DIFF
--- a/organizer/settings.py
+++ b/organizer/settings.py
@@ -215,6 +215,17 @@ CORS_ALLOWED_ORIGINS = config(
 )
 
 
+# python-decouple keeps everything after `=` as the value (including any trailing `# comment`),
+# so sanitize before casting — this tolerates a stray inline comment or whitespace in a hand-edited
+# .env instead of crashing on import (e.g. `RECURRING_TASKS_HOUR=6  # 6am`).
+def _strip_inline_comment(value):
+    return str(value).split("#", 1)[0].strip()
+
+
+def _env_int(key, default):
+    return config(key, default=default, cast=lambda v: int(_strip_inline_comment(v)))
+
+
 # Celery — drives recurring-task generation via celery beat. The broker is Redis by default.
 # The REST API does not require Celery; only automatic task generation depends on it. Generation can
 # always be run manually with `manage.py generate_recurring_tasks` if the broker is unavailable.
@@ -226,23 +237,16 @@ CELERY_TIMEZONE = TIME_ZONE
 CELERY_BEAT_SCHEDULE = {
     "generate-recurring-tasks": {
         "task": "tasks.generate_recurring_tasks",
-        # Daily at a configurable hour (local CELERY_TIMEZONE).
-        "schedule": crontab(minute=0, hour=config("RECURRING_TASKS_HOUR", default=6, cast=int)),
+        # Daily at a configurable hour (local CELERY_TIMEZONE). Sanitized so a stray inline comment
+        # in .env (e.g. `RECURRING_TASKS_HOUR=6  # 6am`) doesn't crash the worker/beat on startup.
+        "schedule": crontab(minute=0, hour=_env_int("RECURRING_TASKS_HOUR", 6)),
     },
 }
 
 
 # --- MCP server + OAuth 2.1 authorization server -----------------------------------------
-# python-decouple keeps everything after `=` as the value (including any trailing `# comment`),
-# so sanitize before use — this tolerates a stray inline comment or whitespace in a
-# hand-edited .env instead of crashing on import (e.g. `OAUTH_ACCESS_TOKEN_TTL=28800  # 8h`).
-def _strip_inline_comment(value):
-    return str(value).split("#", 1)[0].strip()
-
-
-def _env_int(key, default):
-    return config(key, default=default, cast=lambda v: int(_strip_inline_comment(v)))
-
+# (_strip_inline_comment / _env_int are defined above, near the Celery config — they tolerate a
+# stray inline comment in a hand-edited .env, e.g. `OAUTH_ACCESS_TOKEN_TTL=28800  # 8h`.)
 
 # Public, externally-reachable base URL of this deployment. It anchors the OAuth issuer and
 # the MCP resource identifier advertised in discovery metadata, so it MUST match the URL the


### PR DESCRIPTION
## Problem
`python-decouple` keeps everything after `=` (including a trailing `# comment`) as the raw value. So a hand-edited prod `.env` line like:

```
RECURRING_TASKS_HOUR=6        # hour of day (0–23) the daily job runs
```

made `config("RECURRING_TASKS_HOUR", default=6, cast=int)` raise `ValueError: invalid literal for int() with base 10: '6        # hour…'` **at settings import**, which crashed the celery worker **and** beat on startup (the REST API/ASGI app was unaffected).

## Fix
Reuse the existing `_strip_inline_comment` / `_env_int` sanitizers (already used by the MCP/OAuth settings for the same reason). Hoisted them just above the Celery block so both places share one definition, and switched the hour to `_env_int("RECURRING_TASKS_HOUR", 6)`.

## Verified
- `RECURRING_TASKS_HOUR='6  # comment' manage.py check` → passes (previously ValueError).
- `celery -A organizer beat --help` (the exact path in the traceback) → loads config cleanly.
- `ruff check` clean; recurrence tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)